### PR TITLE
fix imagePullSecrets helper func

### DIFF
--- a/charts/nsq/Chart.yaml
+++ b/charts/nsq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nsq
 description: A realtime distributed messaging platform
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: 1.2.1
 home: https://github.com/nsqio/helm-chart/tree/master/charts/nsq
 icon: https://nsq.io/static/img/nsq_blue.png

--- a/charts/nsq/templates/_helpers.tpl
+++ b/charts/nsq/templates/_helpers.tpl
@@ -84,11 +84,11 @@ Return the proper Docker Image Registry Secret Names
   {{- $pullSecrets := list }}
   
   {{- range .Values.imagePullSecrets -}}
-    {{- $pullSecrets = append $pullSecrets . -}}
+    {{- $pullSecrets = append $pullSecrets .name -}}
   {{- end -}}
   
   {{- range .Values.metrics.image.pullSecrets -}}
-    {{- $pullSecrets = append $pullSecrets . -}}
+    {{- $pullSecrets = append $pullSecrets .name -}}
   {{- end -}}
   {{- if (not (empty $pullSecrets)) }}
 imagePullSecrets:


### PR DESCRIPTION
## What?
Fix imagePullSecret helper function

## Why?
When using imagePullSecrets in the **values.yaml** like:

```
imagePullSecrets:
  - name: secret1
  - name: secret2
```
the **nsqd-lookupd** and **nsqd-admin** deployment append it correct using:

```
{{- with .Values.imagePullSecrets }}
      imagePullSecrets:
        {{- toYaml . | nindent 8 }}
{{- end }}
```

The **nsqd-statefulset** however uses the helper function:
```
{{- include "nsq.imagePullSecrets" . | nindent 6 }}
```

which results in the deployment to look like:

```
imagePullSecrets:
  - name: map[name:secret1]
  - name: map[name:secret2]
```

The pull secrets can't be resolved leading to an img pull error in the deployment.

## How?
When building the list in the helper function, use only the name instead if the key,value pair.




