### PR TITLE
fix placement of priorityClassName

### DIFF
--- a/charts/nsq/templates/nsqadmin-deployment.yaml
+++ b/charts/nsq/templates/nsqadmin-deployment.yaml
@@ -10,7 +10,6 @@ spec:
   selector:
     matchLabels:
       {{- include "nsq.nsqadmin.selectorLabels" . | nindent 6 }}
-  priorityClassName: {{ .Values.nsqadmin.priorityClassName }}
   template:
     metadata:
       {{- with .Values.nsqadmin.podAnnotations }}
@@ -25,6 +24,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.nsqadmin.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.nsqadmin.priorityClassName }}
       containers:
       - name: {{ include "nsq.nsqadmin.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"

--- a/charts/nsq/templates/nsqd-statefulset.yaml
+++ b/charts/nsq/templates/nsqd-statefulset.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "nsq.nsqd.selectorLabels" . | nindent 6 }}
-  priorityClassName: {{ .Values.nsqd.priorityClassName }}
   template:
     metadata:
       {{- with .Values.nsqd.podAnnotations }}
@@ -24,6 +23,7 @@ spec:
       {{- include "nsq.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- toYaml .Values.nsqd.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.nsqd.priorityClassName }}
       containers:
       - name: {{ include "nsq.nsqd.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"

--- a/charts/nsq/templates/nsqlookupd-statefulset.yaml
+++ b/charts/nsq/templates/nsqlookupd-statefulset.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "nsq.nsqlookupd.selectorLabels" . | nindent 6 }}
-  priorityClassName: {{ .Values.nsqlookupd.priorityClassName }}
   template:
     metadata:
       {{- with .Values.nsqlookupd.podAnnotations }}
@@ -27,6 +26,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.nsqlookupd.podSecurityContext | nindent 8 }}
+      priorityClassName: {{ .Values.nsqlookupd.priorityClassName }}
       containers:
       - name: {{ include "nsq.nsqlookupd.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"


### PR DESCRIPTION
This PR moves `priorityClassName` inside the PodSpec of statefulsets and deployments.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#podspec-v1-core
