### PR TITLE
fix podAnnotations usage in templates

### DIFF
--- a/charts/nsq/Chart.yaml
+++ b/charts/nsq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nsq
 description: A realtime distributed messaging platform
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: 1.2.1
 home: https://github.com/nsqio/helm-chart/tree/master/charts/nsq
 icon: https://nsq.io/static/img/nsq_blue.png

--- a/charts/nsq/templates/nsqadmin-deployment.yaml
+++ b/charts/nsq/templates/nsqadmin-deployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       {{- with .Values.nsqadmin.podAnnotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/nsq/templates/nsqd-statefulset.yaml
+++ b/charts/nsq/templates/nsqd-statefulset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       {{- with .Values.nsqd.podAnnotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/nsq/templates/nsqlookupd-statefulset.yaml
+++ b/charts/nsq/templates/nsqlookupd-statefulset.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       {{- with .Values.nsqlookupd.podAnnotations }}
+      annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
now following the pattern already used for ingress and service annotations:

https://github.com/nsqio/helm-chart/blob/0f6d7038316ac3234a8c70f8ff199df32f73c289/charts/nsq/templates/ingress.yaml#L14-L17

https://github.com/nsqio/helm-chart/blob/0f6d7038316ac3234a8c70f8ff199df32f73c289/charts/nsq/templates/nsqd-service.yaml#L8-L11

and bump chart version to 0.0.8

fixes #10 with the fix suggested by @alanorther