### PR TITLE
fix tplValues.render helper name

### DIFF
--- a/charts/nsq/Chart.yaml
+++ b/charts/nsq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nsq
 description: A realtime distributed messaging platform
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: 1.2.1
 home: https://github.com/nsqio/helm-chart/tree/master/charts/nsq
 icon: https://nsq.io/static/img/nsq_blue.png

--- a/charts/nsq/templates/metrics-service.yaml
+++ b/charts/nsq/templates/metrics-service.yaml
@@ -20,7 +20,7 @@ spec:
       protocol: TCP
       name: http-metrics
     {{- if .Values.metrics.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
+    {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: 
     {{- include "nsq.nsqd.selectorLabels" . | nindent 4 }}

--- a/charts/nsq/templates/metrics-service.yaml
+++ b/charts/nsq/templates/metrics-service.yaml
@@ -20,7 +20,7 @@ spec:
       protocol: TCP
       name: http-metrics
     {{- if .Values.metrics.service.extraPorts }}
-    {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
+    {{- include "nsq.tplvalues.render" (dict "value" .Values.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: 
     {{- include "nsq.nsqd.selectorLabels" . | nindent 4 }}

--- a/charts/nsq/templates/servicemonitor.yaml
+++ b/charts/nsq/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "nsq.serviceMonitor.namespace" . }}
   labels:
     {{- if .Values.metrics.serviceMonitor.labels }}
-    {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- include "nsq.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: metrics
 spec:
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- include "nsq.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
       app.kubernetes.io/component: metrics
   endpoints:
@@ -28,10 +28,10 @@ spec:
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.relabelings }}
-      relabelings: {{- include "nsq.tplValues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      relabelings: {{- include "nsq.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{- include "nsq.tplValues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      metricRelabelings: {{- include "nsq.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}

--- a/charts/nsq/templates/servicemonitor.yaml
+++ b/charts/nsq/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "nsq.serviceMonitor.namespace" . }}
   labels:
     {{- if .Values.metrics.serviceMonitor.labels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: metrics
 spec:
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- include "nsq.tplValues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
       app.kubernetes.io/component: metrics
   endpoints:
@@ -28,10 +28,10 @@ spec:
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.relabelings }}
-      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      relabelings: {{- include "nsq.tplValues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
+      metricRelabelings: {{- include "nsq.tplValues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}


### PR DESCRIPTION
Error in question:
```
Error: template: nsq/charts/nsq/templates/servicemonitor.yaml:9:8: executing "nsq/charts/nsq/templates/servicemonitor.yaml" at <include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $)>: error calling include: template: no template "common.tplvalues.render" associated with template "gotpl"
```

This PR fixes a typo in the template.  `common.tplvalues.render` is not defined in the chart, and it should read `nsq.tplvalues.render`

Also increment chart patch version
