### PR TITLE
Metrics Prom scrape annotation

### DIFF
--- a/charts/nsq/values.yaml
+++ b/charts/nsq/values.yaml
@@ -178,7 +178,7 @@ metrics:
   service:
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.ports.metrics }}"
+      prometheus.io/port: "{{ .Values.metrics.containerPort }}"
       prometheus.io/path: "/metrics"
     type: ClusterIP
     ports:


### PR DESCRIPTION
The Service port is not used for scraping. The actual Endpoints resources
part of Service are at 9117 (targetPort/containerPort). The best practice
for scraping metrics is to do that against Pods and/or Endpoints, not Services
ports directly. It is known to cause issues if more than one endpoint is behind
the service, as metric queries will be load-balanced as well leading to
inaccurate histograms.

![image](https://github.com/nsqio/helm-chart/assets/39332/c604dd1c-cf4d-4d06-a8d7-0e2d2fcfe94b)
