### PR TITLE
update metrics service prometheus port annotation

### DIFF
--- a/charts/nsq/Chart.yaml
+++ b/charts/nsq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nsq
 description: A realtime distributed messaging platform
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: 1.2.1
 home: https://github.com/nsqio/helm-chart/tree/master/charts/nsq
 icon: https://nsq.io/static/img/nsq_blue.png

--- a/charts/nsq/values.yaml
+++ b/charts/nsq/values.yaml
@@ -178,7 +178,7 @@ metrics:
   service:
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.ports.metrics }}"
+      prometheus.io/port: "{{ .Values.metrics.containerPort }}"
       prometheus.io/path: "/metrics"
     type: ClusterIP
     ports:

--- a/charts/nsq/values.yaml
+++ b/charts/nsq/values.yaml
@@ -177,6 +177,10 @@ metrics:
 
   service:
     annotations:
+      # Prometheus does not connect to this service directly,
+      # instead it uses this port to connect to each target
+      # of the service (each nsqd).
+      # TODO: remove service and annotate pods instead?
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.metrics.containerPort }}"
       prometheus.io/path: "/metrics"


### PR DESCRIPTION
I've added a comment next to the annotations to make it more clear how this is apparently suppose to work.

A copy of https://github.com/nsqio/helm-chart/pull/18 because the original author @wreis closed it and deleted the branch (understandably, after a long time in apparent limbo).

For users of this chart, that enable prometheus metrics and don't customize the ports, nothing actually changes - because the service port and pod port matches by default.